### PR TITLE
Add support of UTF-16 strings

### DIFF
--- a/api/tts.py
+++ b/api/tts.py
@@ -115,7 +115,7 @@ def sendText(text,reset=True,pitch=50,speed=50,quality=50,tone=50,accent=50,into
     text = text.replace("<bleep>","\x1b\\mrk=6\\").replace("</bleep>","\x1b\\mrk=7\\")
     text = text.replace("<echo>","\x1b\\mrk=4\\").replace("</echo>","\x1b\\mrk=5\\")
     text=text+"\0"
-    emu.write_memory(textDataAddr,text.encode('utf-8'))
+    emu.write_memory(textDataAddr,text.encode('utf-16le'))
 
     writeJob(bpm,stretch,pitch,speed,quality,tone,accent,intonation,songData) # default values
 

--- a/gamePatch/source/main.c
+++ b/gamePatch/source/main.c
@@ -61,6 +61,17 @@ int wcslen(const uint16_t* start)
     return end - start;
 }
 
+// Receives UTF-16 string and stores it in memory
+uint16_t* utfRecv(uint16_t* in,int* len){
+	int inLen = wcslen(in);
+	*len = inLen;
+	uint16_t* out = (uint16_t*)tmalloc(*len*2);
+	for (int i = 0; i <= inLen; i++){
+		out[i] = in[i];
+	}
+	return out;
+}
+
 void callTTS(uint16_t* text){
 	int textSize = wcslen(text)*2;
 	ttsGlobal* ttsGlob = getTtsGlobal();
@@ -129,7 +140,8 @@ void mainLoopF(){
 
 			// save the text data
 			int textSize = 0;
-			uint16_t* text = utfTo16((char*)textDataLoc,&textSize);
+			//uint16_t* text = utfTo16((char*)textDataLoc,&textSize);
+			uint16_t* text = utfRecv((uint16_t*)textDataLoc,&textSize);
 
 			if (audioJob->songDataSize == 0){
 				callTTS(text);


### PR DESCRIPTION
This PR changes gamePatch and TTS API code to accept UTF-16 encoding for TTS prompts instead of UTF-8.

### Problem

In prior versions, the prompt for TTS sent through the web app is processed as UTF-8 string. In `tts.py` of web stack:

```python
emu.write_memory(textDataAddr,text.encode('utf-8'))
```

On the emulator's side, that string is processed by a patched function called `utfTo16` that writes UTF-8 symbols into UTF-16 little-endian string (which is the expected format for the in-game TTS engine). In `main.c` of gamePatch source code:

```c
uint16_t* utfTo16(char* in,int* len){
    int inLen = strlen(in)+1;
    *len = inLen*2;
    uint16_t* out = (uint16_t*)tmalloc(*len);
    for (int i = 0; i < inLen; i++){
        out[i] = in[i];
    }
    return out;
```

While it works fine for Latin symbols, the non-Latin ones (e.g. Cyrillic, kanji), being encoded as 2-byte structs, are treated as a sequence of 2 1-byte characters, thus getting an unnecessary zero padding. The problem with encoding becomes apparent, as Python mixes 1-byte and 2-byte characters during UTF-8 encoding.

### Solution

The main addition to gamePatch code is the `utfRecv` function that accepts an array of UTF-16 symbols and writes them down into the memory. It uses `wcslen()` function for calculating wide char string size.  In `main.c` of gamePatch source code:

```c
uint16_t* utfRecv(uint16_t* in,int* len){
    int inLen = wcslen(in);
    *len = inLen;
    uint16_t* out = (uint16_t*)tmalloc(*len*2);
    for (int i = 0; i <= inLen; i++){
        out[i] = in[i];
    }
    return out;
}
```

The function serves as a substitute for `utfTo16` function. In `mainLoopF` function:
```c
uint16_t* text = utfRecv((uint16_t*)textDataLoc,&textSize);
```

On the web app's side, an exact encoding has to be specified in order to be accepted by TTS engine. In `tts.py` of web stack:
```python
emu.write_memory(textDataAddr,text.encode('utf-16le'))
```
The code has been tested in a local environment with changes specified above. <echo> and <bleep> tags are working, as well as singing functionality.

This PR allows for implementing the support of non-Latin languages (e.g. Russian, Chinese, Japanese, Korean) in the future.